### PR TITLE
fix: ignore ufw error when prepare is not enabled

### DIFF
--- a/roles/node_launch/tasks/main.yml
+++ b/roles/node_launch/tasks/main.yml
@@ -2,10 +2,12 @@
 - name: open prometheus port
   become: true
   command: 'ufw allow {{ custom_port_prefix }}660/tcp'
+  ignore_errors: (prepare is defined) and (prepare|bool is false)
 
 - name: open p2p port
   become: true
   command: 'ufw allow {{ custom_port_prefix }}656/tcp'
+  ignore_errors: (prepare is defined) and (prepare|bool is false)
 
 - name: Create cosmovisor directories
   file:

--- a/roles/support_cosmos_exporter/tasks/main.yml
+++ b/roles/support_cosmos_exporter/tasks/main.yml
@@ -11,6 +11,7 @@
 - name: open cosmos exporter port
   become: true
   command: 'ufw allow {{ custom_port_prefix }}300/tcp'
+  ignore_errors: (prepare is defined) and (prepare|bool is false)
 
 - name: start cosmos exporter service
   become: true

--- a/roles/support_seed/tasks/main.yml
+++ b/roles/support_seed/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: open p2p port
   become: true
   command: 'ufw allow {{ custom_port_prefix }}656/tcp'
+  ignore_errors: (prepare is defined) and (prepare|bool is false)
 
 - name: Create folder
   file:


### PR DESCRIPTION
- Reason for not using `when` is because if in case UFW is there then it will work else we'll just ignore the error