### PR TITLE
Fix genesis.json.gz copy

### DIFF
--- a/roles/node_initialize/tasks/genesis_gz.yml
+++ b/roles/node_initialize/tasks/genesis_gz.yml
@@ -11,4 +11,4 @@
   copy:
     remote_src: true
     src: /tmp/genesis.json
-    dest: '{{ user_dir }}/{{ folder }}/config'
+    dest: '{{ user_dir }}/{{ folder }}/config/genesis.json'


### PR DESCRIPTION
I have tried your script with genesis.json.gz, but it is not working on my end.

The reason is that `dest` is a folder, not a file.

```
dest: '{{ user_dir }}/{{ folder }}/config'
```

I fix it by adding "/genesis.json" to `dest`.

```
dest: '{{ user_dir }}/{{ folder }}/config/genesis.json'
```